### PR TITLE
fix: don't adjust stake decimal point from ledger json

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -336,7 +336,6 @@ async fn batch_patch_witness(opts: VRFOpts) -> Result<()> {
                 .ok_or(anyhow!("can't find delegator"))?
                 .balance,
         )?;
-        balance.set_scale(DIGITS_AFTER_DECIMAL_POINT)?;
         patched.vrf_threshold = Some(BatchPatchWitnessSingleVrfThresholdRequest {
             delegated_stake: balance.to_string(),
             total_stake: total_currency.to_string(),

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -329,7 +329,7 @@ async fn batch_patch_witness(opts: VRFOpts) -> Result<()> {
     let iterator = deserializer.into_iter::<BatchPatchWitnessSingleRequest>();
     for item in iterator {
         let mut patched = item?;
-        let mut balance = Decimal::from_str(
+        let balance = Decimal::from_str(
             &delegators
                 .iter()
                 .find(|x| x.index == patched.message.delegator_index)


### PR DESCRIPTION
Thanks to @garethtdavies, we saw that the balance in the ledger JSON is already in MINA and doesn't need to be adjusted.
