### PR TITLE
fix: write to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ An example workflow - proving to a delegator your eligible blocks:
 
 ```
 cargo run --release -- batch-generate-witness --pub B62qrHzjcZbYSsrcXVgGko7go1DzSEBfdQGPon5X4LEGExtNJZA4ECj --epoch 5 > requests
-cat requests | mina advanced vrf batch-generate-witness --privkey-path /keys/my-wallet | grep -v CODA_PRIVKEY_PASS > witnesses
+cat requests | mina advanced vrf batch-generate-witness --privkey-path /keys/my-wallet | sed 's/Using password from environment variable CODA_PRIVKEY_PASS//g' > witnesses
 ```
 
 Send `witnesses` to delegator.
@@ -29,7 +29,7 @@ Send `witnesses` to delegator.
 
 ```
 cat witnesses | cargo run --release -- batch-patch-witness --pub B62qrHzjcZbYSsrcXVgGko7go1DzSEBfdQGPon5X4LEGExtNJZA4ECj --epoch 5 > patches
-cat patches | mina advanced vrf batch-check-witness | grep -v CODA_PRIVKEY_PASS > check
+cat patches | mina advanced vrf batch-check-witness | sed 's/Using password from environment variable CODA_PRIVKEY_PASS//g' > check
 cat check | cargo run --release -- batch-check-witness --pub B62qrHzjcZbYSsrcXVgGko7go1DzSEBfdQGPon5X4LEGExtNJZA4ECj --epoch 5
 ```
 

--- a/scripts/end_to_end.sh
+++ b/scripts/end_to_end.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -xe
+
+PUBKEY=$1
+EPOCH=$2
+
+cargo run --release -- batch-generate-witness --pub $PUBKEY --epoch $EPOCH > requests
+cat requests | mina advanced vrf batch-generate-witness --privkey-path /keys/my-wallet | sed 's/Using password from environment variable CODA_PRIVKEY_PASS//g' > witnesses
+cat witnesses | cargo run --release -- batch-patch-witness --pub $PUBKEY --epoch $EPOCH > patches
+cat patches | mina advanced vrf batch-check-witness | sed 's/Using password from environment variable CODA_PRIVKEY_PASS//g' > check
+cat check | cargo run --release -- batch-check-witness --pub $PUBKEY --epoch $EPOCH


### PR DESCRIPTION
As part of recent updates, the program mistakenly moved the outputs from stdout to the usual logging flow in stderr. This broke the flow used in the README and by users.

This PR fixes it and provides a few improvements on the way:
* The output of the `check` commands is now a structured JSON. The old output is now logged to stderr.
* End-to-end testing script, through which this PR was tested.
* More robust method to remove the CODA PASSWORD like messages now described in the README.

Closes #25, #14 (handles the open question that remained there).

cc @garethtdavies @lampardlamps